### PR TITLE
Fixes error message when team name does not validate.

### DIFF
--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -23,12 +23,14 @@ output_option = click.option('-o', '--output', type=click.Choice(['text', 'json'
 
 url_option = click.option('--url', help='Pier One URL', metavar='URI')
 
-TEAM_PATTERN = re.compile(r'^[a-z][a-z0-9-]+$')
+TEAM_PATTERN_STR = r'[a-z][a-z0-9-]+'
+TEAM_PATTERN = re.compile(r'^{}$'.format(TEAM_PATTERN_STR))
 
 
 def validate_team(ctx, param, value):
     if not TEAM_PATTERN.match(value):
-        raise click.BadParameter('Team ID must satisfy regular expression pattern "[a-z][a-z0-9]+"')
+        msg = 'Team ID must satisfy regular expression pattern "{}"'.format(TEAM_PATTERN_STR)
+        raise click.BadParameter(msg)
     return value
 
 


### PR DESCRIPTION
#19 was already fixed, but error message was still the old expression.