### PR TITLE
Call for tokens in "latest" like the other sub-commands

### DIFF
--- a/pierone/api.py
+++ b/pierone/api.py
@@ -99,16 +99,12 @@ def image_exists(token_name: str, image: DockerImage) -> bool:
     return image.tag in result
 
 
-def get_latest_tag(token_name: str, image: DockerImage) -> bool:
-    token = get_existing_token(token_name)
-    if not token:
-        raise Unauthorized()
-
+def get_latest_tag(token: str, image: DockerImage) -> bool:
     url = 'https://{}'.format(image.registry)
     path = '/teams/{team}/artifacts/{artifact}/tags'.format(team=image.team, artifact=image.artifact)
 
     try:
-        r = request(url, path, token['access_token'])
+        r = request(url, path, token)
         r.raise_for_status()
     except:
         return None

--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -13,6 +13,7 @@ import zign.api
 from clickclick import AliasedGroup, OutputFormat, UrlType, error, print_table
 
 from .api import DockerImage, docker_login, get_latest_tag, request
+from .exceptions import PieroneException
 
 KEYRING_KEY = 'pierone'
 
@@ -354,7 +355,11 @@ def latest(config, team, artifact, url, output):
         registry = registry[8:]
     image = DockerImage(registry=registry, team=team, artifact=artifact, tag=None)
 
-    print(get_latest_tag(token, image))
+    latest_tag = get_latest_tag(token, image)
+    if latest_tag:
+        print(latest_tag)
+    else:
+        raise PieroneException('Latest tag not found')
 
 
 @cli.command('scm-source')

--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -347,14 +347,14 @@ def latest(config, team, artifact, url, output):
     '''Get latest tag/version of a specific artifact'''
     # validate that the token exists!
     set_pierone_url(config, url)
-    get_token()
+    token = get_token()
 
     registry = config.get('url')
     if registry.startswith('https://'):
         registry = registry[8:]
     image = DockerImage(registry=registry, team=team, artifact=artifact, tag=None)
 
-    print(get_latest_tag('pierone', image))
+    print(get_latest_tag(token, image))
 
 
 @cli.command('scm-source')

--- a/pierone/exceptions.py
+++ b/pierone/exceptions.py
@@ -1,0 +1,5 @@
+from click import ClickException
+
+
+class PieroneException(ClickException):
+    '''Thrown when something does not go as expected'''

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -132,19 +132,6 @@ def test_get_latest_tag_non_json(monkeypatch):
     assert data is None
 
 
-def test_unauthorized(monkeypatch):
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value=None))
-    token_name = 'dummy'
-    image = DockerImage(registry='registry', team='foo', artifact='bar', tag='latest')
-    with pytest.raises(Unauthorized) as excinfo:
-        get_latest_tag(token_name, image)
-    assert 'Unauthorized: token missing or invalid' in str(excinfo.value)
-
-    with pytest.raises(Unauthorized) as excinfo:
-        image_exists(token_name, image)
-    assert 'Unauthorized: token missing or invalid' in str(excinfo.value)
-
-
 def test_image_exists(monkeypatch):
     response = MagicMock()
     response.status_code = 200

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -248,7 +248,8 @@ def test_latest_not_found(monkeypatch, tmpdir):
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ['latest', 'myteam', 'myart'], catch_exceptions=False)
-        assert 'None' == result.output.rstrip()
+        assert 'Error: Latest tag not found' == result.output.rstrip()
+        assert result.exit_code == 1
 
 
 def test_url_without_scheme(monkeypatch, tmpdir):


### PR DESCRIPTION
We should be uniform in how to get tokens to use in subcommands. User reported:
```
Traceback (most recent call last):
  File "/usr/local/bin/pierone", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.5/site-packages/pierone/cli.py", line 342, in main
    cli()
  File "/usr/local/lib/python3.5/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.5/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.5/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.5/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/click/decorators.py", line 27, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/pierone/cli.py", line 214, in latest
    print(get_latest_tag('pierone', image))
  File "/usr/local/lib/python3.5/site-packages/pierone/api.py", line 105, in get_latest_tag
    raise Unauthorized()
pierone.api.Unauthorized: Unauthorized: token missing or invalid
```

But other sub-commands work fine, like "pierone tags". The only reason it is not working for the `latest` sub-command is because it calls for the pierone token in a different way than other sub-commands. This PR makes `latest` call for tokens the same way.