### PR TITLE
Expose Pierone API

### DIFF
--- a/pierone/api.py
+++ b/pierone/api.py
@@ -8,7 +8,7 @@ import time
 
 import requests
 from clickclick import Action
-from zign.api import get_existing_token, get_named_token
+from zign.api import get_named_token
 
 adapter = requests.adapters.HTTPAdapter(pool_connections=10, pool_maxsize=10)
 session = requests.Session()

--- a/pierone/api.py
+++ b/pierone/api.py
@@ -5,7 +5,6 @@ import json
 import os
 import re
 import time
-from typing import Optional
 
 import requests
 from clickclick import Action
@@ -113,14 +112,14 @@ def image_exists(token_name: str, image: DockerImage) -> bool:
     return image.tag in result
 
 
-def get_image_tag(token_name: str, image: DockerImage) -> Optional[dict]:
+def get_image_tag(token_name: str, image: DockerImage) -> dict:
     for entry in get_image_tags(token_name, image):
         if entry['tag'] == image.tag:
             return entry
     return None
 
 
-def get_image_tags(token_name: str, image: DockerImage) -> Optional[list]:
+def get_image_tags(token_name: str, image: DockerImage) -> list:
     token = get_existing_token(token_name)
     if not token:
         raise Unauthorized()

--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -211,7 +211,8 @@ def tags(config, team: str, artifact, url, output, limit):
     if not artifact:
         artifact = get_artifacts(config.get('url'), team, token)
         if not artifact:
-            raise click.UsageError('Either Team does not exist or currently does not artifacts in Pierone! '
+            raise click.UsageError('The Team you are looking for does not exist or '
+                                   'we could not find any artifacts registered in Pierone! '
                                    'Please double check for spelling mistakes.')
 
     registry = config.get('url')
@@ -224,14 +225,14 @@ def tags(config, team: str, artifact, url, output, limit):
     for art in artifact:
         image = DockerImage(registry=registry, team=team, artifact=art, tag=None)
         try:
-            tags = get_image_tags('pierone', image)[slice_from:]
+            tags = get_image_tags(image, token)
         except Unauthorized as e:
             raise click.ClickException(str(e))
         else:
             if tags is None:
                 raise click.UsageError('Artifact or Team does not exist! '
                                        'Please double check for spelling mistakes.')
-            rows.extend(tags)
+            rows.extend(tags[slice_from:])
 
     # sorts are guaranteed to be stable, i.e. tags will be sorted by time (as returned from REST service)
     rows.sort(key=lambda row: (row['team'], row['artifact']))
@@ -306,7 +307,7 @@ def latest(config, team, artifact, url, output):
         registry = registry[8:]
     image = DockerImage(registry=registry, team=team, artifact=artifact, tag=None)
 
-    latest_tag = get_latest_tag(token, image)
+    latest_tag = get_latest_tag(image, token)
     if latest_tag:
         print(latest_tag)
     else:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,11 +2,9 @@ import json
 import os
 from unittest.mock import MagicMock, ANY
 
-import pytest
 import yaml
-from pierone.api import (DockerImage, Unauthorized, docker_login,
-                         get_image_tag, get_image_tags, get_latest_tag,
-                         image_exists)
+from pierone.api import (DockerImage, docker_login, get_image_tag,
+                         get_image_tags, get_latest_tag, image_exists)
 
 import requests.exceptions
 
@@ -116,10 +114,8 @@ def test_get_latest_tag(monkeypatch):
                                    'created_by': 'foobar',
                                    'name': '0.21'}]
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
-    token_name = 'dummy'
     image = DockerImage(registry='registry', team='foo', artifact='bar', tag='latest')
-    data = get_latest_tag(token_name, image)
+    data = get_latest_tag(image)
 
     assert data == '0.22'
 
@@ -146,10 +142,8 @@ def test_get_latest_tag_IOException(monkeypatch):
                                    'created_by': 'foobar',
                                    'name': '0.21'}]
     monkeypatch.setattr('pierone.api.session.get', MagicMock(side_effect=Exception(IOError), return_value=response))
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
-    token_name = 'dummy'
     image = DockerImage(registry='registry', team='foo', artifact='bar', tag='latest')
-    data = get_latest_tag(token_name, image)
+    data = get_latest_tag(image)
 
     assert data is None
 
@@ -159,10 +153,8 @@ def test_get_latest_tag_non_json(monkeypatch):
     response.status_code = 200
     response.json.return_value = None
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
-    token_name = 'dummy'
     image = DockerImage(registry='registry', team='foo', artifact='bar', tag='latest')
-    data = get_latest_tag(token_name, image)
+    data = get_latest_tag(image)
 
     assert data is None
 
@@ -173,10 +165,8 @@ def test_image_exists(monkeypatch):
     response.json.return_value = {'0.1': 'chksum',
                                   '0.2': 'chksum'}
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
-    token_name = 'dummy'
     image = DockerImage(registry='registry', team='foo', artifact='bar', tag='0.2')
-    data = image_exists(token_name, image)
+    data = image_exists(image)
 
     assert data is True
 
@@ -187,10 +177,8 @@ def test_image_exists_IOException(monkeypatch):
     response.json.return_value = {'0.1': 'chksum',
                                   '0.2': 'chksum'}
     monkeypatch.setattr('pierone.api.session.get', MagicMock(side_effect=Exception(IOError), return_value=response))
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
-    token_name = 'dummy'
     image = DockerImage(registry='registry', team='foo', artifact='bar', tag='0.2')
-    data = image_exists(token_name, image)
+    data = image_exists(image)
 
     assert data is False
 
@@ -201,10 +189,8 @@ def test_image_exists_but_other_version(monkeypatch):
     response.json.return_value = {'0.1': 'chksum',
                                   '0.2': 'chksum'}
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
-    token_name = 'dummy'
     image = DockerImage(registry='registry', team='foo', artifact='bar', tag='latest')
-    data = image_exists(token_name, image)
+    data = image_exists(image)
 
     assert data is False
 
@@ -214,10 +200,8 @@ def test_image_not_exists(monkeypatch):
     response.status_code = 404
     response.json.return_value = {}
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
-    token_name = 'dummy'
     image = DockerImage(registry='registry', team='foo', artifact='bar', tag='latest')
-    data = image_exists(token_name, image)
+    data = image_exists(image, 'tok123')
 
     assert data is False
 
@@ -229,11 +213,9 @@ def test_get_image_tags(monkeypatch):
                                    'created_by': 'foobar',
                                    'name': '0.17'}]
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
-    token_name = 'dummy'
     image = DockerImage(registry='registry', team='foo', artifact='bar', tag=None)
 
-    image_tags = get_image_tags(token_name, image)
+    image_tags = get_image_tags(image)
     tag = image_tags[0]
 
     assert tag['team'] == 'foo'
@@ -254,11 +236,9 @@ def test_get_image_tag(monkeypatch):
                                    'created_by': 'foobar',
                                    'name': '0.22'}]
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
-    token_name = 'dummy'
     image = DockerImage(registry='registry', team='foo', artifact='bar', tag='0.22')
 
-    tag = get_image_tag(token_name, image)
+    tag = get_image_tag(image)
 
     assert tag['team'] == 'foo'
     assert tag['artifact'] == 'bar'
@@ -275,8 +255,6 @@ def test_get_image_tag_that_does_not_exist(monkeypatch):
                                    'created_by': 'foobar',
                                    'name': '0.17'}]
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
-    token_name = 'dummy'
     image = DockerImage(registry='registry', team='foo', artifact='bar', tag='1.22')
 
-    assert get_image_tag(token_name, image) is None
+    assert get_image_tag(image) is None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ import os
 from unittest.mock import MagicMock, ANY
 
 import yaml
+import pytest
 from pierone.api import (DockerImage, docker_login, get_image_tag,
                          get_image_tags, get_latest_tag, image_exists)
 
@@ -20,7 +21,8 @@ def test_docker_login(monkeypatch, tmpdir):
     path = os.path.expanduser('~/.docker/config.json')
     with open(path) as fd:
         data = yaml.safe_load(fd)
-        assert {'auth': 'b2F1dGgyOjEyMzc3', 'email': 'no-mail-required@example.org'} == data.get('auths').get('https://pierone.example.org')
+        assert {'auth': 'b2F1dGgyOjEyMzc3',
+                'email': 'no-mail-required@example.org'} == data.get('auths').get('https://pierone.example.org')
 
 
 def test_docker_login_service_token(monkeypatch, tmpdir):
@@ -30,7 +32,8 @@ def test_docker_login_service_token(monkeypatch, tmpdir):
     path = os.path.expanduser('~/.docker/config.json')
     with open(path) as fd:
         data = yaml.safe_load(fd)
-        assert {'auth': 'b2F1dGgyOjEyMzc3', 'email': 'no-mail-required@example.org'} == data.get('auths').get('https://pierone.example.org')
+        assert {'auth': 'b2F1dGgyOjEyMzc3',
+                'email': 'no-mail-required@example.org'} == data.get('auths').get('https://pierone.example.org')
 
 
 @pytest.mark.parametrize(
@@ -88,7 +91,8 @@ def test_keep_dockercfg_entries(monkeypatch, tmpdir):
                  'myuser', 'mypass', 'https://token.example.org', use_keyring=False)
     with open(path) as fd:
         data = yaml.safe_load(fd)
-        assert {'auth': 'b2F1dGgyOjEyMzc3', 'email': 'no-mail-required@example.org'} == data.get('auths', {}).get('https://pierone.example.org')
+        assert {'auth': 'b2F1dGgyOjEyMzc3',
+                'email': 'no-mail-required@example.org'} == data.get('auths', {}).get('https://pierone.example.org')
         assert existing_data.get(key) == data.get(key)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,7 +52,7 @@ def test_login_arg_user(monkeypatch, tmpdir):
     monkeypatch.setattr('requests.get', lambda x, timeout: response)
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['login', '-U', arg_user], catch_exceptions=False, input='pieroneurl\n')
+        runner.invoke(cli, ['login', '-U', arg_user], catch_exceptions=False, input='pieroneurl\n')
 
 
 def test_login_zign_user(monkeypatch, tmpdir):
@@ -72,7 +72,7 @@ def test_login_zign_user(monkeypatch, tmpdir):
     monkeypatch.setattr('requests.get', lambda x, timeout: response)
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['login'], catch_exceptions=False, input='pieroneurl\n')
+        runner.invoke(cli, ['login'], catch_exceptions=False, input='pieroneurl\n')
 
 
 def test_login_env_user(monkeypatch, tmpdir):
@@ -91,7 +91,7 @@ def test_login_env_user(monkeypatch, tmpdir):
     monkeypatch.setattr('requests.get', lambda x, timeout: response)
 
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['login'], catch_exceptions=False, input='pieroneurl\n')
+        runner.invoke(cli, ['login'], catch_exceptions=False, input='pieroneurl\n')
 
 
 def test_login_given_url_option(monkeypatch, tmpdir):
@@ -222,7 +222,6 @@ def test_tags(monkeypatch, tmpdir):
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'foobar'})
     monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='tok123'))
     monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ['tags', 'myteam', 'myart'], catch_exceptions=False)
@@ -270,7 +269,6 @@ def test_tags_versions_limit(monkeypatch, tmpdir):
     runner = CliRunner()
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'foobar'})
     monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='tok123'))
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
     monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
     monkeypatch.setattr('pierone.cli.get_artifacts', MagicMock(return_value=artifacts))
     monkeypatch.setattr('pierone.cli.get_image_tags', MagicMock(return_value=tags))
@@ -399,7 +397,6 @@ def test_latest(monkeypatch, tmpdir):
     runner = CliRunner()
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'https://pierone.example.org'})
     monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='tok123'))
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ['latest', 'myteam', 'myart'], catch_exceptions=False)
@@ -412,7 +409,6 @@ def test_latest_not_found(monkeypatch, tmpdir):
     runner = CliRunner()
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'https://pierone.example.org'})
     monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='tok123'))
-    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ['latest', 'myteam', 'myart'], catch_exceptions=False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -222,6 +222,7 @@ def test_tags(monkeypatch, tmpdir):
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'foobar'})
     monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='tok123'))
     monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ['tags', 'myteam', 'myart'], catch_exceptions=False)
@@ -238,17 +239,29 @@ def test_tags_versions_limit(monkeypatch, tmpdir):
     artifacts = ['app1', 'app2']
     tags = [
         {
-            'name': '1.0',
+            'tag': '1.0',
+            'team': 'foo',
+            'artifact': 'app1',
+            'severity_fix_available': 'TOO_OLD',
+            'severity_no_fix_available': 'TOO_OLD',
             'created_by': 'myuser',
             'created': '2015-08-01T08:14:59.432Z'
         },
         {
-            'name': '1.1',
+            'tag': '1.1',
+            'team': 'foo',
+            'artifact': 'app1',
+            'severity_fix_available': 'NO_CVES_FOUND',
+            'severity_no_fix_available': 'NO_CVES_FOUND',
             'created_by': 'myuser',
             'created': '2015-08-02T08:14:59.432Z'
         },
         {
-            'name': '2.0',
+            'tag': '2.0',
+            'team': 'foo',
+            'artifact': 'app1',
+            'severity_fix_available': 'NO_CVES_FOUND',
+            'severity_no_fix_available': 'NO_CVES_FOUND',
             'created_by': 'myuser',
             'created': '2016-06-20T08:14:59.432Z'
         },
@@ -257,9 +270,10 @@ def test_tags_versions_limit(monkeypatch, tmpdir):
     runner = CliRunner()
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'foobar'})
     monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='tok123'))
+    monkeypatch.setattr('pierone.api.get_existing_token', MagicMock(return_value={'access_token': 'tok123'}))
     monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
     monkeypatch.setattr('pierone.cli.get_artifacts', MagicMock(return_value=artifacts))
-    monkeypatch.setattr('pierone.cli.get_tags', MagicMock(return_value=tags))
+    monkeypatch.setattr('pierone.cli.get_image_tags', MagicMock(return_value=tags))
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ['tags', 'myteam', '--limit=1'], catch_exceptions=False)
         assert '1.0' not in result.output


### PR DESCRIPTION
In order to support the development of https://github.com/zalando-stups/senza/issues/223 we need to expose in a reusable way the Pierone API.

This refactor also handle some possible missusage of pierone-cli when having some misspeling in the team or artifact name.