### PR TITLE
Limit versions

### DIFF
--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -258,14 +258,18 @@ def artifacts(config, team, url, output):
 @click.argument('artifact', nargs=-1)
 @url_option
 @output_option
+@click.option('--versions', type=int, default=3)
 @click.pass_obj
-def tags(config, team: str, artifact, url, output):
+def tags(config, team: str, artifact, url, output, versions):
     '''List all tags for a given team'''
     set_pierone_url(config, url)
     token = get_token()
 
     if not artifact:
         artifact = get_artifacts(config.get('url'), team, token)
+        slice_from = - versions
+    else:
+        slice_from = 0
 
     rows = []
     for art in artifact:
@@ -279,7 +283,7 @@ def tags(config, team: str, artifact, url, output):
                           row.get('severity_fix_available'), row.get('clair_id', False)),
                       'severity_no_fix_available': parse_severity(
                           row.get('severity_no_fix_available'), row.get('clair_id', False))}
-                     for row in r])
+                     for row in r[slice_from:]])
 
     # sorts are guaranteed to be stable, i.e. tags will be sorted by time (as returned from REST service)
     rows.sort(key=lambda row: (row['team'], row['artifact']))

--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -258,18 +258,21 @@ def artifacts(config, team, url, output):
 @click.argument('artifact', nargs=-1)
 @url_option
 @output_option
-@click.option('--versions', type=int, default=3)
+@click.option('-l', '--limit', type=int, help='Limit number of versions to show per artifact')
 @click.pass_obj
-def tags(config, team: str, artifact, url, output, versions):
+def tags(config, team: str, artifact, url, output, limit):
     '''List all tags for a given team'''
     set_pierone_url(config, url)
     token = get_token()
 
+    if limit is None:
+        # show 20 rows if artifact was given, else show only 3
+        limit = 20 if artifact else 3
+
     if not artifact:
         artifact = get_artifacts(config.get('url'), team, token)
-        slice_from = - versions
-    else:
-        slice_from = 0
+
+    slice_from = - limit
 
     rows = []
     for art in artifact:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -257,7 +257,7 @@ def test_tags_versions_limit(monkeypatch, tmpdir):
     monkeypatch.setattr('pierone.cli.get_artifacts', MagicMock(return_value=artifacts))
     monkeypatch.setattr('pierone.cli.get_tags', MagicMock(return_value=tags))
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['tags', 'myteam', '--versions=1'], catch_exceptions=False)
+        result = runner.invoke(cli, ['tags', 'myteam', '--limit=1'], catch_exceptions=False)
         assert '1.0' not in result.output
         assert '1.1' not in result.output
         assert '2.0' in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -230,6 +230,39 @@ def test_tags(monkeypatch, tmpdir):
         assert re.search('HIGH\s+MEDIUM', result.output), 'Should how information about CVEs'
 
 
+def test_tags_versions_limit(monkeypatch, tmpdir):
+    artifacts = ['app1', 'app2']
+    tags = [
+        {
+            'name': '1.0',
+            'created_by': 'myuser',
+            'created': '2015-08-01T08:14:59.432Z'
+        },
+        {
+            'name': '1.1',
+            'created_by': 'myuser',
+            'created': '2015-08-02T08:14:59.432Z'
+        },
+        {
+            'name': '2.0',
+            'created_by': 'myuser',
+            'created': '2016-06-20T08:14:59.432Z'
+        },
+    ]
+
+    runner = CliRunner()
+    monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'foobar'})
+    monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='tok123'))
+    monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('pierone.cli.get_artifacts', MagicMock(return_value=artifacts))
+    monkeypatch.setattr('pierone.cli.get_tags', MagicMock(return_value=tags))
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ['tags', 'myteam', '--versions=1'], catch_exceptions=False)
+        assert '1.0' not in result.output
+        assert '1.1' not in result.output
+        assert '2.0' in result.output
+
+
 def test_cves(monkeypatch, tmpdir):
     pierone_service_payload = [
         # Former pierone payload


### PR DESCRIPTION
Implementing the `--limit` (`-l`) option for `pierone tags`:

* default is to only show the most recent 3 versions per artifact if no artifact was specified
* default is to show the most recent 20 versions if an artifact was specified