### PR TITLE
Make special status less prominent compared to real CVEs

### DIFF
--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -26,16 +26,10 @@ url_option = click.option('--url', help='Pier One URL', metavar='URI')
 
 CVE_STYLES = {
     'TOO_OLD': {
-        'bold': True,
-        'fg': 'red'
     },
     'NOT_PROCESSED_YET': {
-        'bold': True,
-        'fg': 'red'
     },
     'COULDNT_FIGURE_OUT': {
-        'bold': True,
-        'fg': 'red'
     },
     'CRITICAL': {
         'bold': True,


### PR DESCRIPTION
Currently, `CLOUDNT_FIGURE_OUT`, `TOO_OLD` and `NOT_YET_PROCESSED` are highlighted equally strong as `HIGH` and `CRITICAL` CVEs. The default font color has a stark contrast to the background anyways and is very prominent compared with `MEDIUM`, so drop the color and boldness of the special status and make `HIGH` and `CRITICAL` easier to spot.