### PR TITLE
Show error when artifact is not found in scm-source command

### DIFF
--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -229,7 +229,7 @@ def tags(config, team: str, artifact, url, output, limit):
         except Unauthorized as e:
             raise click.ClickException(str(e))
         else:
-            if tags is None:
+            if not tags:
                 raise click.UsageError('Artifact or Team does not exist! '
                                        'Please double check for spelling mistakes.')
             rows.extend(tags[slice_from:])
@@ -327,6 +327,9 @@ def scm_source(config, team, artifact, tag, url, output):
     token = get_token()
 
     tags = get_tags(config.get('url'), team, artifact, token)
+    if not tags:
+        raise click.UsageError('Artifact or Team does not exist! '
+                               'Please double check for spelling mistakes.')
 
     if not tag:
         tag = [t['name'] for t in tags]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,13 +128,20 @@ def test_scm_source(monkeypatch, tmpdir):
     runner = CliRunner()
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'foobar'})
     monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='tok123'))
-    monkeypatch.setattr('pierone.cli.get_tags', MagicMock(return_value={}))
+    monkeypatch.setattr('pierone.cli.get_tags', MagicMock(return_value=[{'name': 'myart'}]))
     monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ['scm-source', 'myteam', 'myart', '1.0'], catch_exceptions=False)
         assert 'myrev123' in result.output
         assert 'git:somerepo' in result.output
+
+    # no tags found
+    monkeypatch.setattr('pierone.cli.get_tags', MagicMock(return_value=[]))
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ['scm-source', 'myteam', 'myart', '1.0'], catch_exceptions=False)
+        assert 'Artifact or Team does not exist!' in result.output
+        assert result.exit_code > 0
 
 
 def test_image(monkeypatch, tmpdir):


### PR DESCRIPTION
When using `$ pierone scm-source team notexist` it was returning an empty output and no error (exit code `0`). Now it shows message that the artifact or team does not exist and returns non-zero as exit code.

//cc @ainmosni 
