### PR TITLE
Improve HTTP error handling

### DIFF
--- a/pierone/api.py
+++ b/pierone/api.py
@@ -53,6 +53,7 @@ class DockerImage(collections.namedtuple('DockerImage', 'registry team artifact 
 
 
 def docker_login(url, realm, name, user, password, token_url=None, use_keyring=True, prompt=False):
+    token = None  # Make linters happy
     with Action('Getting OAuth2 token "{}"..'.format(name)) as action:
         try:
             token = get_named_token(['uid', 'application.write'],
@@ -67,7 +68,6 @@ def docker_login(url, realm, name, user, password, token_url=None, use_keyring=T
                 action.fatal_error('Authentication Failed ({} Server Error).'.format(status_code))
             else:
                 action.fatal_error('Authentication Failed ({})'.format(status_code))
-            token = None # Make linters happy
     access_token = token.get('access_token')
     docker_login_with_token(url, access_token)
 
@@ -92,7 +92,7 @@ def docker_login_with_token(url, access_token):
             json.dump(dockercfg, fd)
 
 
-def request(url, path, access_token: str=None, not_found_is_none: bool=False) -> requests.Response:
+def request(url, path, access_token: str = None, not_found_is_none: bool = False) -> requests.Response:
     if access_token:
         headers = {'Authorization': 'Bearer {}'.format(access_token)}
     else:
@@ -105,7 +105,7 @@ def request(url, path, access_token: str=None, not_found_is_none: bool=False) ->
         return r
 
 
-def image_exists(image: DockerImage, token: str=None) -> bool:
+def image_exists(image: DockerImage, token: str = None) -> bool:
     url = 'https://{}'.format(image.registry)
     path = '/v1/repositories/{team}/{artifact}/tags'.format(team=image.team, artifact=image.artifact)
 
@@ -116,7 +116,7 @@ def image_exists(image: DockerImage, token: str=None) -> bool:
     return image.tag in result
 
 
-def get_image_tag(image: DockerImage, token: str=None) -> dict:
+def get_image_tag(image: DockerImage, token: str = None) -> dict:
     tags = get_image_tags(image, token) or []
     for entry in tags:
         if entry['tag'] == image.tag:
@@ -124,7 +124,7 @@ def get_image_tag(image: DockerImage, token: str=None) -> dict:
     return None
 
 
-def get_image_tags(image: DockerImage, token: str=None) -> list:
+def get_image_tags(image: DockerImage, token: str = None) -> list:
     url = 'https://{}'.format(image.registry)
     path = '/teams/{team}/artifacts/{artifact}/tags'.format(team=image.team, artifact=image.artifact)
 
@@ -135,7 +135,7 @@ def get_image_tags(image: DockerImage, token: str=None) -> list:
             for entry in response.json()]
 
 
-def get_latest_tag(image: DockerImage, token: str=None) -> bool:
+def get_latest_tag(image: DockerImage, token: str = None) -> bool:
     url = 'https://{}'.format(image.registry)
     path = '/teams/{team}/artifacts/{artifact}/tags'.format(team=image.team, artifact=image.artifact)
 

--- a/pierone/api.py
+++ b/pierone/api.py
@@ -67,6 +67,7 @@ def docker_login(url, realm, name, user, password, token_url=None, use_keyring=T
                 action.fatal_error('Authentication Failed ({} Server Error).'.format(status_code))
             else:
                 action.fatal_error('Authentication Failed ({})'.format(status_code))
+            token = None # Make linters happy
     access_token = token.get('access_token')
     docker_login_with_token(url, access_token)
 
@@ -91,20 +92,25 @@ def docker_login_with_token(url, access_token):
             json.dump(dockercfg, fd)
 
 
-def request(url, path, access_token: str=None) -> requests.Response:
-    headers = {}
+def request(url, path, access_token: str=None, not_found_is_none: bool=False) -> requests.Response:
     if access_token:
         headers = {'Authorization': 'Bearer {}'.format(access_token)}
-    return session.get('{}{}'.format(url, path), headers=headers, timeout=10)
+    else:
+        headers = {}
+    r = session.get('{}{}'.format(url, path), headers=headers, timeout=10)
+    if not_found_is_none and r.status_code == 404:
+        return None
+    else:
+        r.raise_for_status()
+        return r
 
 
 def image_exists(image: DockerImage, token: str=None) -> bool:
     url = 'https://{}'.format(image.registry)
     path = '/v1/repositories/{team}/{artifact}/tags'.format(team=image.team, artifact=image.artifact)
 
-    try:
-        r = request(url, path, token)
-    except:
+    r = request(url, path, token, True)
+    if r is None:
         return False
     result = r.json()
     return image.tag in result
@@ -122,10 +128,9 @@ def get_image_tags(image: DockerImage, token: str=None) -> list:
     url = 'https://{}'.format(image.registry)
     path = '/teams/{team}/artifacts/{artifact}/tags'.format(team=image.team, artifact=image.artifact)
 
-    response = request(url, path, token)
-    if response.status_code == 404:
+    response = request(url, path, token, True)
+    if response is None:
         return None
-
     return [parse_pierone_artifact_dict(entry, image.team, image.artifact)
             for entry in response.json()]
 
@@ -134,10 +139,8 @@ def get_latest_tag(image: DockerImage, token: str=None) -> bool:
     url = 'https://{}'.format(image.registry)
     path = '/teams/{team}/artifacts/{artifact}/tags'.format(team=image.team, artifact=image.artifact)
 
-    try:
-        r = request(url, path, token)
-        r.raise_for_status()
-    except:
+    r = request(url, path, token, True)
+    if r is None:
         return None
     result = r.json()
     if result:

--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -344,7 +344,7 @@ def scm_source(config, team, artifact, tag, url, output):
     rows = []
     for t in tag:
         r = request(config.get('url'), '/teams/{}/artifacts/{}/tags/{}/scm-source'.format(team, artifact, t),
-                      token, True)
+                    token, True)
         if r is None:
             row = {}
         else:

--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -167,12 +167,10 @@ def get_artifacts(url, team: str, access_token):
 
 
 def get_tags(url, team, art, access_token):
-    r = request(url, '/teams/{}/artifacts/{}/tags'.format(team, art), access_token)
-    if r.status_code == 404:
+    r = request(url, '/teams/{}/artifacts/{}/tags'.format(team, art), access_token, True)
+    if r is None:
         # empty list of tags (artifact does not exist)
         return []
-    else:
-        r.raise_for_status()
     return r.json()
 
 
@@ -180,12 +178,10 @@ def get_clair_features(clair_details_url, access_token):
     if not clair_details_url:
         return []
 
-    r = request(clair_details_url, '?vulnerabilities&features', access_token)
-    if r.status_code == 404:
+    r = request(clair_details_url, '?vulnerabilities&features', access_token, True)
+    if r is None:
         # empty list of tags (layer does not exist)
         return []
-    else:
-        r.raise_for_status()
 
     return r.json()['Layer'].get('Features', [])
 
@@ -347,10 +343,12 @@ def scm_source(config, team, artifact, tag, url, output):
 
     rows = []
     for t in tag:
-        row = request(config.get('url'), '/teams/{}/artifacts/{}/tags/{}/scm-source'.format(team, artifact, t),
-                      token).json()
-        if not row:
+        r = request(config.get('url'), '/teams/{}/artifacts/{}/tags/{}/scm-source'.format(team, artifact, t),
+                      token, True)
+        if r is None:
             row = {}
+        else:
+            row = r.json()
         row['tag'] = t
         matching_tag = [d for d in tags if d['name'] == t]
         row['created_by'] = ''.join([d['created_by'] for d in matching_tag])
@@ -376,14 +374,16 @@ def image(config, image, url, output):
     set_pierone_url(config, url)
     token = get_token()
 
-    resp = request(config.get('url'), '/tags/{}'.format(image), token)
-
-    if resp.status_code == 404:
-        click.echo('Image {} not found'.format(image))
-        return
-
-    if resp.status_code == 412:
-        click.echo('Prefix {} matches more than one image.'.format(image))
+    try:
+        resp = request(config.get('url'), '/tags/{}'.format(image), token)
+    except requests.HTTPError as error:
+        status_code = error.response.status_code
+        if status_code == 404:
+            click.echo('Image {} not found'.format(image))
+        elif status_code == 412:
+            click.echo('Prefix {} matches more than one image.'.format(image))
+        else:
+            raise error
         return
 
     tags = resp.json()

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ def read_version(package):
         exec(fd.read(), data)
     return data['__version__']
 
+
 NAME = 'stups-pierone'
 MAIN_PACKAGE = 'pierone'
 VERSION = read_version(MAIN_PACKAGE)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -125,31 +125,13 @@ def test_get_latest_tag(monkeypatch):
 
 
 def test_get_latest_tag_IOException(monkeypatch):
-    response = MagicMock()
-    response.status_code = 200
-    response.json.return_value = [{'created': '2015-06-01T14:12:03.276+0000',
-                                   'created_by': 'foobar',
-                                   'name': '0.17'},
-                                  {'created': '2015-06-11T15:27:34.672+0000',
-                                   'created_by': 'foobar',
-                                   'name': '0.18'},
-                                  {'created': '2015-06-11T16:13:29.152+0000',
-                                   'created_by': 'foobar',
-                                   'name': '0.22'},
-                                  {'created': '2015-06-11T15:36:55.033+0000',
-                                   'created_by': 'foobar',
-                                   'name': '0.19'},
-                                  {'created': '2015-06-11T15:45:50.225+0000',
-                                   'created_by': 'foobar',
-                                   'name': '0.20'},
-                                  {'created': '2015-06-11T15:51:49.307+0000',
-                                   'created_by': 'foobar',
-                                   'name': '0.21'}]
-    monkeypatch.setattr('pierone.api.session.get', MagicMock(side_effect=Exception(IOError), return_value=response))
+    monkeypatch.setattr('pierone.api.session.get', MagicMock(side_effect=IOError))
     image = DockerImage(registry='registry', team='foo', artifact='bar', tag='latest')
-    data = get_latest_tag(image)
-
-    assert data is None
+    try:
+        get_latest_tag(image)
+        assert False
+    except IOError as e:
+        pass  # Expected
 
 
 def test_get_latest_tag_non_json(monkeypatch):
@@ -180,11 +162,13 @@ def test_image_exists_IOException(monkeypatch):
     response.status_code = 200
     response.json.return_value = {'0.1': 'chksum',
                                   '0.2': 'chksum'}
-    monkeypatch.setattr('pierone.api.session.get', MagicMock(side_effect=Exception(IOError), return_value=response))
+    monkeypatch.setattr('pierone.api.session.get', MagicMock(side_effect=IOError(), return_value=response))
     image = DockerImage(registry='registry', team='foo', artifact='bar', tag='0.2')
-    data = image_exists(image)
-
-    assert data is False
+    try:
+        image_exists(image)
+        assert False
+    except IOError as e:
+        pass  # Expected
 
 
 def test_image_exists_but_other_version(monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -437,6 +437,7 @@ def test_latest(monkeypatch, tmpdir):
 def test_latest_not_found(monkeypatch, tmpdir):
     response = MagicMock()
     response.raise_for_status.side_effect = Exception('FAIL')
+    response.status_code = 404
     runner = CliRunner()
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'https://pierone.example.org'})
     monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='tok123'))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 from click.testing import CliRunner
 from pierone.cli import cli
-from requests import RequestException
+from requests import RequestException, HTTPError
 
 
 @pytest.fixture(autouse=True)
@@ -169,19 +169,44 @@ def test_scm_source(monkeypatch, tmpdir):
 
 
 def test_image(monkeypatch, tmpdir):
-    response = MagicMock()
-    response.json.return_value = [{'name': '1.0', 'team': 'stups', 'artifact': 'kio'}]
-
     runner = CliRunner()
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'foobar'})
     monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='tok123'))
     monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+
+    response = MagicMock()
+    response.json.return_value = [{'name': '1.0', 'team': 'stups', 'artifact': 'kio'}]
     monkeypatch.setattr('pierone.api.session.get', MagicMock(return_value=response))
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ['image', 'abcd'], catch_exceptions=False)
+        assert result.exit_code == 0
         assert 'kio' in result.output
         assert 'stups' in result.output
         assert '1.0' in result.output
+
+    monkeypatch.setattr('pierone.api.session.get', MagicMock(side_effect=Exception("Some unknown error")))
+    with runner.isolated_filesystem():
+        try:
+            runner.invoke(cli, ['image', 'abcd'], catch_exceptions=False)
+            assert False
+        except Exception as e:
+           assert e.args[0] == "Some unknown error"
+
+    response404 = MagicMock()
+    response404.status_code = 404
+    monkeypatch.setattr('pierone.api.session.get', MagicMock(side_effect=HTTPError(response=response404)))
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ['image', 'abcd'], catch_exceptions=False)
+        # assert result.exit_code != 0
+        assert "not found" in result.output
+
+    response412 = MagicMock()
+    response412.status_code = 412
+    monkeypatch.setattr('pierone.api.session.get', MagicMock(side_effect=HTTPError(response=response412)))
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ['image', 'abcd'], catch_exceptions=False)
+        # assert result.exit_code != 0
+        assert "more than one" in result.output
 
 
 def test_tags(monkeypatch, tmpdir):


### PR DESCRIPTION
Errors in call to pierone.api.request were handled inconsistently
or not handled at all in some cases.
This lead to hard to understand error messages/stack traces
that were caused by HTTP errors.
In some cases error messages were outright misleading as message
"Image not found" actually meant "Cannot process at the moment".
Thus reporting images that do present in repository as missing.

This version strives not not hide or obfuscate errors in case they are not handled explicitly.

Further improvement could be to print exception's stack trace only with --verbose flag defaulting to exception's message only.