### PR TITLE
fixes a reference to deprecated docker config

### DIFF
--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -127,7 +127,7 @@ def cli(ctx):
 @click.option('-p', '--password', help='Password to use for authentication', envvar='PIERONE_PASSWORD', metavar='PWD')
 @click.pass_obj
 def login(config, url, realm, name, user, password):
-    '''Login to Pier One Docker registry (generates ~/.dockercfg'''
+    '''Login to Pier One Docker registry (generates docker configuration in ~/.docker/config.json)'''
     url_option_was_set = url
     url = set_pierone_url(config, url)
     user = user or zign.api.get_config().get('user') or os.getenv('USER')


### PR DESCRIPTION
Local docker client was previously configured by using `~/.dockercfg`.
Docker (and pierone-cli) has migrated to the new configuration file
`~/.docker/config.json`. This commit fixes a reference to `~/.dockercfg`
which is visible in the cli help:

```
% pierone login --help
Usage: pierone login [OPTIONS]

  Login to Pier One Docker registry (generates ~/.dockercfg
```