### PR TITLE
show trusted status for images

### DIFF
--- a/pierone/api.py
+++ b/pierone/api.py
@@ -171,7 +171,8 @@ def parse_pierone_artifact_dict(original_payload_from_api, team, artifact) -> di
                 original_payload_from_api.get('clair_id', False)),
             'severity_no_fix_available': parse_severity(
                 original_payload_from_api.get('severity_no_fix_available'),
-                original_payload_from_api.get('clair_id', False))}
+                original_payload_from_api.get('clair_id', False)),
+            'trusted': original_payload_from_api.get('trusted')}
 
 
 def parse_time(s: str) -> float:

--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -212,12 +212,13 @@ def tags(config, team: str, artifact, url, output, limit):
 
     # sorts are guaranteed to be stable, i.e. tags will be sorted by time (as returned from REST service)
     rows.sort(key=lambda row: (row['team'], row['artifact']))
+
     with OutputFormat(output):
         titles = {
             'created_time': 'Created',
             'created_by': 'By'
         }
-        print_table(['team', 'artifact', 'tag', 'created_time', 'created_by'], rows, titles=titles)
+        print_table(['team', 'artifact', 'tag', 'created_time', 'created_by', 'trusted'], rows, titles=titles)
 
 
 @cli.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -278,6 +278,18 @@ def test_tags(monkeypatch, tmpdir):
             "clair_details": "https://clair.example.org/foo/",
             "severity_fix_available": "High",
             "severity_no_fix_available": "Medium"
+        },
+        # New pierone payload with info about image trusted status
+        {
+            "name": "1.2",
+            "created": "2016-05-23T13:29:17.753Z",
+            "created_by": "myuser",
+            "image": "sha256:here",
+            "clair_id": "sha256:here",
+            "clair_details": "https://clair.example.org/foo/",
+            "severity_fix_available": "High",
+            "severity_no_fix_available": "Medium",
+            "trusted": "true"
         }
     ]
 


### PR DESCRIPTION
pierone now returns `trusted` status for images.
Adding trusted column to `pierone tags` to expose this information.