### PR TITLE
Fix 'pierone login' on Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 install:
   - pip install -r requirements.txt
   - pip install coveralls
+  - pip install 'pytest>=3.6'
   - pip install flake8 # forcing installation of flake8, might be removed after https://gitlab.com/pycqa/flake8/issues/164 gets fixed.
 script:
   - python setup.py test

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,28 +40,7 @@ def test_docker_login(monkeypatch, tmpdir):
         data = yaml.safe_load(fd)
         assert {'auth': 'b2F1dGgyOjEyMzc3',
                 'email': 'no-mail-required@example.org'} == data.get('auths').get('https://pierone.example.org')
-
-def test_docker_login_with_credsstore(monkeypatch, tmpdir):
-    monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
-    path = os.path.expanduser('~/.docker/config.json')
-    os.makedirs(os.path.dirname(path))
-    with open(path, 'w') as fd:
-        json.dump({
-            "auths": {
-                "https://pierone.stups.zalan.do": {
-                    "auth": "xxx",
-                    "email": "no-mail-required@example.org"
-                }
-            },
-            "credsStore": "osxkeychain"
-        }, fd)
-    docker_login('https://pierone.example.org', 'services', 'mytok',
-                 'myuser', 'mypass', 'https://token.example.org', use_keyring=False)
-    with open(path) as fd:
-        data = yaml.safe_load(fd)
-        assert {'auth': 'b2F1dGgyOjEyMzc3',
-                'email': 'no-mail-required@example.org'} == data.get('auths').get('https://pierone.example.org')
-        assert 'credsStore' not in data
+        assert "" == data.get('credHelpers', {}).get('pierone.example.org')
 
 
 def test_docker_login_service_token(monkeypatch, tmpdir):


### PR DESCRIPTION
Docker for Mac uses the Keychain credentials helper by default, which causes the auth token to be ignored. There was an attempt at fixing it by deleting the `credsStore` key, but the actual key is called `credSstore` ¯\\\_(ツ)\_/¯.
Instead of removing stuff from the user's Docker config, just configure the URL to not use a credentials helper explicitly.