### PR TITLE
validators.py: allow team names to contain underscores

### DIFF
--- a/pierone/validators.py
+++ b/pierone/validators.py
@@ -8,7 +8,7 @@ import click
 
 INCIDENT_PATTERN = re.compile(r'^INC-\d+$')
 
-TEAM_PATTERN_STR = r'[a-z][a-z0-9-]+'
+TEAM_PATTERN_STR = r'[a-z][a-z0-9_-]+'
 TEAM_PATTERN = re.compile(r'^{}$'.format(TEAM_PATTERN_STR))
 
 


### PR DESCRIPTION
Bug report: https://groups.google.com/a/zalando.de/d/msg/zooport-stork/IQ4_-aQxKw4/u0DaPEEFAQAJ.

> unfortunately, out Team ID eaa_di_ds does not comply with pierone naming conventions. Therefore I get this error whenever I use pierone to interact with my team's repo.
> `Error: Invalid value for "TEAM": 'eaa_di_ds' doesn't satisfy regular expression pattern '[a-z][a-z0-9-]+'`