### PR TITLE
Respect `DOCKER_CONFIG` environment variable (closes #88)

### DIFF
--- a/pierone/api.py
+++ b/pierone/api.py
@@ -12,7 +12,7 @@ from zign.api import get_token
 
 from .exceptions import ArtifactNotFound, Forbidden, Conflict, UnprocessableEntity
 from .types import DockerImage
-from .utils import get_user_friendly_user_name
+from .utils import get_user_friendly_user_name, get_docker_config_path
 
 adapter = requests.adapters.HTTPAdapter(pool_connections=10, pool_maxsize=10)
 session = requests.Session()
@@ -21,7 +21,6 @@ session.mount('https://', adapter)
 
 
 class PierOne:
-
     def __init__(self, url: str):
         self.url = url if url.startswith("https://") else "https://" + url
         self._access_token = get_token('pierone', ['uid'])
@@ -159,7 +158,7 @@ def docker_login(url, realm, name, user, password, token_url=None, use_keyring=T
 def docker_login_with_token(url, access_token):
     '''Configure docker with existing OAuth2 access token'''
 
-    path = os.path.expanduser('~/.docker/config.json')
+    path = get_docker_config_path('config.json')
     try:
         with open(path) as fd:
             dockercfg = json.load(fd)
@@ -192,7 +191,7 @@ def iid_auth():
 def docker_login_with_iid(url):
     '''Configure docker with IID auth'''
 
-    path = os.path.expanduser('~/.docker/config.json')
+    path = get_docker_config_path('config.json')
     try:
         with open(path) as fd:
             dockercfg = json.load(fd)

--- a/pierone/utils.py
+++ b/pierone/utils.py
@@ -1,3 +1,5 @@
+import os
+
 KNOWN_USERS = {
     "credprov-cdp-controller-proxy_pierone-token": "[CDP]",
     "credprov-cdp-controller-proxy-credentials-cdp_proxy-token": "[CDP]",
@@ -16,6 +18,15 @@ def get_user_friendly_user_name(long_user_name: str) -> str:
     Try to make long user names more user friendly by mapping known long user names to short
     versions.
 
-    IF the user name is not "known" it is return unchanged.
+    If the user name is not "known" it is return unchanged.
     """
     return KNOWN_USERS.get(long_user_name, long_user_name)
+
+
+def get_docker_config_path(filename: str) -> str:
+    """
+    Return the path to a Docker config file.
+    """
+    directory = os.environ.get('DOCKER_CONFIG', '~/.docker')
+    path = os.path.join(directory, filename)
+    return os.path.expanduser(path)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,11 +31,13 @@ def make_error_response(status_code: int):
 
 
 def test_docker_login(monkeypatch, tmpdir):
-    monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('pierone.utils.get_docker_config_path', lambda path: os.path.join(str(tmpdir), path))
     monkeypatch.setattr('pierone.api.get_token', MagicMock(return_value='12377'))
+
     docker_login('https://pierone.example.org', 'services', 'mytok',
                  'myuser', 'mypass', 'https://token.example.org', use_keyring=False)
-    path = os.path.expanduser('~/.docker/config.json')
+
+    path = os.path.join(str(tmpdir), 'config.json')
     with open(path) as fd:
         data = yaml.safe_load(fd)
         assert {'auth': 'b2F1dGgyOjEyMzc3',
@@ -44,10 +46,12 @@ def test_docker_login(monkeypatch, tmpdir):
 
 
 def test_docker_login_service_token(monkeypatch, tmpdir):
-    monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('pierone.utils.get_docker_config_path', lambda path: os.path.join(str(tmpdir), path))
     monkeypatch.setattr('tokens.get', lambda x: '12377')
+
     docker_login('https://pierone.example.org', None, 'mytok', 'myuser', 'mypass', 'https://token.example.org')
-    path = os.path.expanduser('~/.docker/config.json')
+
+    path = os.path.join(str(tmpdir), 'config.json')
     with open(path) as fd:
         data = yaml.safe_load(fd)
         assert {'auth': 'b2F1dGgyOjEyMzc3',
@@ -55,8 +59,7 @@ def test_docker_login_service_token(monkeypatch, tmpdir):
 
 
 def test_docker_login_with_iid(monkeypatch, tmpdir):
-    monkeypatch.setattr('os.path.expanduser',
-                        lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('pierone.utils.get_docker_config_path', lambda path: os.path.join(str(tmpdir), path))
     metaservice = MagicMock()
     metaservice.text = '''TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNldGV0dXIgc2FkaXBzY2luZyBlbGl0ciwg
 c2VkIGRpYW0gbm9udW15IGVpcm1vZCB0ZW1wb3IgaW52aWR1bnQgdXQgbGFib3JlIGV0IGRvbG9y
@@ -71,8 +74,10 @@ IGNsaXRhIGthc2QgZ3ViZXJncmVuLCBubyBzZWEgdGFraW1hdGEgc2FuY3R1cyBlc3QgTG9yZW0g
 aXBzdW0gZG9sb3Igc2l0IGFtZXQuCg=='''
     monkeypatch.setattr('pierone.api.request',
                         MagicMock(return_value=metaservice))
+
     docker_login_with_iid('https://pierone.example.org')
-    path = os.path.expanduser('~/.docker/config.json')
+
+    path = os.path.join(str(tmpdir), 'config.json')
     with open(path) as fd:
         data = yaml.safe_load(fd)
         assert {'auth': 'aW5zdGFuY2UtaWRlbnRpdHktZG9jdW1lbnQ6VEc5eVpXMGdhWEJ6ZFcwZ1pHOXNiM0lnYzJsMElH'
@@ -94,9 +99,10 @@ aXBzdW0gZG9sb3Igc2l0IGFtZXQuCg=='''
 
 
 def test_keep_dockercfg_entries(monkeypatch, tmpdir):
-    monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('pierone.utils.get_docker_config_path', lambda path: os.path.join(str(tmpdir), path))
     monkeypatch.setattr('pierone.api.get_token', MagicMock(return_value='12377'))
-    path = os.path.expanduser('~/.docker/config.json')
+
+    path = os.path.join(str(tmpdir), 'config.json')
 
     key = 'https://old.example.org'
     existing_data = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,7 +73,7 @@ def test_login(monkeypatch, tmpdir):
 
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {})
     monkeypatch.setattr('pierone.api.get_token', MagicMock(return_value='tok123'))
-    monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('pierone.utils.get_docker_config_path', lambda path: os.path.join(str(tmpdir), path))
 
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ['login'], catch_exceptions=False, input='pieroneurl\n')
@@ -90,7 +90,7 @@ def test_invalid_url_for_login(monkeypatch, tmpdir):
 
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {})
     monkeypatch.setattr('pierone.api.get_token', MagicMock(return_value='tok123'))
-    monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('pierone.utils.get_docker_config_path', lambda path: os.path.join(str(tmpdir), path))
 
     # Missing Pier One header
     response.text = 'Not valid API'
@@ -183,7 +183,7 @@ def test_login_given_url_option(monkeypatch, tmpdir):
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {})
     monkeypatch.setattr('stups_cli.config.store_config', store)
     monkeypatch.setattr('pierone.api.get_token', MagicMock(return_value='tok123'))
-    monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('pierone.utils.get_docker_config_path', lambda path: os.path.join(str(tmpdir), path))
 
     with runner.isolated_filesystem():
         runner.invoke(cli, ['login'], catch_exceptions=False, input='pieroneurl\n')
@@ -197,12 +197,13 @@ def test_login_given_url_option(monkeypatch, tmpdir):
 
 
 def test_scm_source(monkeypatch, tmpdir, mock_pierone_api):
-
     runner = CliRunner()
+
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'foobar'})
     monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='tok123'))
     monkeypatch.setattr('pierone.cli.get_tags', MagicMock(return_value=[{'name': 'myart'}]))
-    monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('pierone.utils.get_docker_config_path', lambda path: os.path.join(str(tmpdir), path))
+
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ['scm-source', 'myteam', 'myart', '1.0'], catch_exceptions=False)
         assert 'myrev123' in result.output
@@ -218,9 +219,10 @@ def test_scm_source(monkeypatch, tmpdir, mock_pierone_api):
 
 def test_image(monkeypatch, tmpdir):
     runner = CliRunner()
+
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'foobar'})
     monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='tok123'))
-    monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('pierone.utils.get_docker_config_path', lambda path: os.path.join(str(tmpdir), path))
 
     response = MagicMock()
     response.json.return_value = [{'name': '1.0', 'team': 'stups', 'artifact': 'kio'}]
@@ -335,19 +337,23 @@ def test_tags(monkeypatch, tmpdir, mock_pierone_api):
     ]
 
     runner = CliRunner()
+
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'foobar'})
     monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='tok123'))
-    monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('pierone.utils.get_docker_config_path', lambda path: os.path.join(str(tmpdir), path))
     monkeypatch.setattr('pierone.api.session.request', MagicMock(return_value=response))
+
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ['tags', 'myteam', 'myart'], catch_exceptions=False)
         assert '1.0' in result.output
 
 def test_tags_versions_limit(monkeypatch, tmpdir, mock_pierone_api):
     runner = CliRunner()
+
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {'url': 'foobar'})
     monkeypatch.setattr('zign.api.get_token', MagicMock(return_value='tok123'))
-    monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('pierone.utils.get_docker_config_path', lambda path: os.path.join(str(tmpdir), path))
+
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ['tags', 'myteam', '--limit=1'], catch_exceptions=False)
         assert '1.0' not in result.output

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
 from hypothesis import given, assume
 from hypothesis.strategies import text, lists, integers
+from unittest.mock import patch
 
-from pierone.utils import KNOWN_USERS, get_registry, get_user_friendly_user_name
+from pierone.utils import KNOWN_USERS, get_registry, get_user_friendly_user_name, get_docker_config_path
 
 def test_get_registry():
     assert get_registry("https://pierone.example.org") == "pierone.example.org"
@@ -19,3 +20,10 @@ def test_get_user_friendly_user_name_cdp():
     ]
     for user_name in CDP_USER_NAMES:
         assert get_user_friendly_user_name(user_name) ==  "[CDP]"
+
+def test_get_docker_config_path_default():
+    assert get_docker_config_path('config.json') == os.path.expanduser('~/.docker/config.json')
+
+@patch.dict('os.environ', {'DOCKER_CONFIG': '/etc/docker'})
+def test_get_docker_config_path_environment_override():
+    assert get_docker_config_path('config.json') == '/etc/docker/config.json'


### PR DESCRIPTION
Docker allows setting a custom directory to store its configuration via
the "DOCKER_CONFIG" environment variable. The `pierone` command-line
interface however did not previously read this value if it was present.

This update makes sure `pierone` works with the correct directory and
Docker configuration files.