### PR TITLE
Respect `DOCKER_CONFIG` environment variable (closes #88)

### DIFF
--- a/pierone/utils.py
+++ b/pierone/utils.py
@@ -1,3 +1,5 @@
+import os
+
 KNOWN_USERS = {
     "credprov-cdp-controller-proxy_pierone-token": "[CDP]",
     "credprov-cdp-controller-proxy-credentials-cdp_proxy-token": "[CDP]",
@@ -16,6 +18,15 @@ def get_user_friendly_user_name(long_user_name: str) -> str:
     Try to make long user names more user friendly by mapping known long user names to short
     versions.
 
-    IF the user name is not "known" it is return unchanged.
+    If the user name is not "known" it is return unchanged.
     """
     return KNOWN_USERS.get(long_user_name, long_user_name)
+
+
+def get_docker_config_path(filename: str) -> str:
+    """
+    Return the path to a Docker config file.
+    """
+    directory = os.environ.get('DOCKER_CONFIG', '~/.docker')
+    path = os.path.join(directory, filename)
+    return os.path.expanduser(path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,10 @@
+import os
+
 from hypothesis import given, assume
 from hypothesis.strategies import text, lists, integers
+from unittest.mock import patch
 
-from pierone.utils import KNOWN_USERS, get_registry, get_user_friendly_user_name
+from pierone.utils import KNOWN_USERS, get_registry, get_user_friendly_user_name, get_docker_config_path
 
 def test_get_registry():
     assert get_registry("https://pierone.example.org") == "pierone.example.org"
@@ -19,3 +22,10 @@ def test_get_user_friendly_user_name_cdp():
     ]
     for user_name in CDP_USER_NAMES:
         assert get_user_friendly_user_name(user_name) ==  "[CDP]"
+
+def test_get_docker_config_path_default():
+    assert get_docker_config_path('config.json') == os.path.expanduser('~/.docker/config.json')
+
+@patch.dict('os.environ', {'DOCKER_CONFIG': '/etc/docker'})
+def test_get_docker_config_path_environment_override():
+    assert get_docker_config_path('config.json') == '/etc/docker/config.json'


### PR DESCRIPTION
Docker allows setting a custom directory to store its configuration via
the "DOCKER_CONFIG" environment variable. The `pierone` command-line
interface however did not previously read this value if it was present.

This update makes sure `pierone` works with the correct directory and
Docker configuration files.