### PR TITLE
Fix: Login breaks Docker config (closes #87)

### DIFF
--- a/pierone/api.py
+++ b/pierone/api.py
@@ -4,7 +4,6 @@ import datetime
 import json
 import os
 import time
-from urllib.parse import urlparse
 
 import requests
 from clickclick import Action
@@ -170,11 +169,6 @@ def docker_login_with_token(url, access_token):
     dockercfg['auths'] = dockercfg.get('auths', {})
     dockercfg['auths'][url] = {'auth': basic_auth,
                                'email': 'no-mail-required@example.org'}
-
-    # Explicitly disable credential helpers for the host in URL
-    dockercfg['credHelpers'] = dockercfg.get('credHelpers', {})
-    hostname = urlparse(url).hostname
-    dockercfg['credHelpers'][hostname] = ""
 
     with Action('Storing Docker client configuration in {}..'.format(path)):
         os.makedirs(os.path.dirname(path), exist_ok=True)

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ def setup_package():
         install_requires=install_reqs,
         setup_requires=['six', 'flake8'],
         cmdclass=cmdclass,
-        tests_require=['pytest-cov', 'pytest', "hypothesis"],
+        tests_require=['pytest-cov', 'pytest', "hypothesis<5"],
         command_options=command_options,
         entry_points={'console_scripts': CONSOLE_SCRIPTS},
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,7 +40,6 @@ def test_docker_login(monkeypatch, tmpdir):
         data = yaml.safe_load(fd)
         assert {'auth': 'b2F1dGgyOjEyMzc3',
                 'email': 'no-mail-required@example.org'} == data.get('auths').get('https://pierone.example.org')
-        assert "" == data.get('credHelpers', {}).get('pierone.example.org')
 
 
 def test_docker_login_service_token(monkeypatch, tmpdir):


### PR DESCRIPTION
Setting the "credHelpers" setting to an empty string breaks
authentication for the current version of Docker for Mac –
2.1.0.5 (40693).

Since this setting of the "credHelpers" for the "pierone" domain was
originally introduced to fix authentication specifically for Docker on
Mac (see tag 1.1.41), it looks like it is safe to remove it again.

For context, here's the PR that introduced the `"credHelpers"` modification in the first place:
https://github.com/zalando-stups/pierone-cli/pull/82

I tested with the current Docker for Mac app and it works for me™️ ✌️ 