### PR TITLE
Implement a proper credentials helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.4"
+  - "3.7"
 install:
   - pip install -r requirements.txt
   - pip install coveralls

--- a/pierone/api.py
+++ b/pierone/api.py
@@ -149,6 +149,39 @@ class PierOne:
         )
 
 
+def load_docker_config():
+    path = os.path.expanduser('~/.docker/config.json')
+    try:
+        with open(path) as fd:
+            return json.load(fd)
+    except Exception:
+        return {}
+
+
+def store_docker_config(config):
+    path = os.path.expanduser('~/.docker/config.json')
+    with Action('Storing Docker client configuration in {}..'.format(path)):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w') as fd:
+            json.dump(config, fd, indent=2)
+
+
+def docker_login_with_credhelper(url):
+    dockercfg = load_docker_config()
+
+    dockercfg['auths'] = dockercfg.get('auths', {})
+    try:
+        del dockercfg['auths'][url]
+    except KeyError:
+        pass
+
+    dockercfg['credHelpers'] = dockercfg.get('credHelpers', {})
+    hostname = urlparse(url).hostname
+    dockercfg['credHelpers'][hostname] = "pierone"
+
+    store_docker_config(dockercfg)
+
+
 # all the other paramaters are deprecated, but still here for compatibility
 def docker_login(url, realm, name, user, password, token_url=None, use_keyring=True, prompt=False):
     with Action('Getting OAuth2 token "{}"..'.format(name)):
@@ -158,13 +191,7 @@ def docker_login(url, realm, name, user, password, token_url=None, use_keyring=T
 
 def docker_login_with_token(url, access_token):
     '''Configure docker with existing OAuth2 access token'''
-
-    path = os.path.expanduser('~/.docker/config.json')
-    try:
-        with open(path) as fd:
-            dockercfg = json.load(fd)
-    except Exception:
-        dockercfg = {}
+    dockercfg = load_docker_config()
     basic_auth = codecs.encode('oauth2:{}'.format(access_token).encode('utf-8'), 'base64').strip().decode('utf-8')
 
     dockercfg['auths'] = dockercfg.get('auths', {})
@@ -176,10 +203,7 @@ def docker_login_with_token(url, access_token):
     hostname = urlparse(url).hostname
     dockercfg['credHelpers'][hostname] = ""
 
-    with Action('Storing Docker client configuration in {}..'.format(path)):
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, 'w') as fd:
-            json.dump(dockercfg, fd, indent=2)
+    store_docker_config(dockercfg)
 
 
 def iid_auth():
@@ -191,21 +215,14 @@ def iid_auth():
 
 def docker_login_with_iid(url):
     '''Configure docker with IID auth'''
+    dockercfg = load_docker_config()
 
-    path = os.path.expanduser('~/.docker/config.json')
-    try:
-        with open(path) as fd:
-            dockercfg = json.load(fd)
-    except Exception:
-        dockercfg = {}
     if 'auths' not in dockercfg:
         dockercfg['auths'] = {}
     dockercfg['auths'][url] = {'auth': iid_auth(),
                                'email': 'no-mail-required@example.org'}
-    with Action('Storing Docker client configuration in {}..'.format(path)):
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, 'w') as fd:
-            json.dump(dockercfg, fd)
+
+    store_docker_config(dockercfg)
 
 
 def request(url, path, access_token: str = None,

--- a/pierone/api.py
+++ b/pierone/api.py
@@ -5,6 +5,7 @@ import json
 import os
 import time
 from urllib.parse import urlparse
+import warnings
 
 import requests
 from clickclick import Action
@@ -184,6 +185,7 @@ def docker_login_with_credhelper(url):
 
 # all the other paramaters are deprecated, but still here for compatibility
 def docker_login(url, realm, name, user, password, token_url=None, use_keyring=True, prompt=False):
+    warnings.warn("deprecated", DeprecationWarning)
     with Action('Getting OAuth2 token "{}"..'.format(name)):
         access_token = get_token(name, ['uid', 'application.write'])
     docker_login_with_token(url, access_token)
@@ -191,6 +193,7 @@ def docker_login(url, realm, name, user, password, token_url=None, use_keyring=T
 
 def docker_login_with_token(url, access_token):
     '''Configure docker with existing OAuth2 access token'''
+    warnings.warn("deprecated", DeprecationWarning)
     dockercfg = load_docker_config()
     basic_auth = codecs.encode('oauth2:{}'.format(access_token).encode('utf-8'), 'base64').strip().decode('utf-8')
 

--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -1,22 +1,21 @@
-import os
+import sys
 import tarfile
 import tempfile
 
 import click
-import pierone
 import requests
 import stups_cli.config
 import zign.api
-import sys
 from clickclick import AliasedGroup, OutputFormat, UrlType, error, fatal_error, print_table, ok
 from requests import RequestException
 
+import pierone
 from .api import PierOne, docker_login_with_credhelper, get_latest_tag, parse_time, request
 from .exceptions import PieroneException, ArtifactNotFound
+from .types import DockerImage
 from .ui import DetailsBox, format_full_image_name, markdown_2_cli
 from .utils import get_registry
 from .validators import validate_incident_id, validate_team
-from .types import DockerImage
 
 KEYRING_KEY = 'pierone'
 

--- a/pierone/credhelper.py
+++ b/pierone/credhelper.py
@@ -1,11 +1,19 @@
 import json
+import sys
+
+import click
 import zign.api
 
 
-def main():
-    token = zign.api.get_token("pierone", ["uid", "application.write"])
-    response = {
-        "Username": "oauth2",
-        "Secret": token,
-    }
-    print(json.dumps(response))
+@click.command()
+@click.argument("cmd")
+def main(cmd):
+    if cmd == "get":
+        token = zign.api.get_token("pierone", ["uid", "application.write"])
+        response = {
+            "Username": "oauth2",
+            "Secret": token,
+        }
+        print(json.dumps(response))
+    else:
+        print("Unsupported command: {}".format(cmd), file=sys.stderr)

--- a/pierone/credhelper.py
+++ b/pierone/credhelper.py
@@ -1,0 +1,11 @@
+import json
+import zign.api
+
+
+def main():
+    token = zign.api.get_token("pierone", ["uid", "application.write"])
+    response = {
+        "Username": "oauth2",
+        "Secret": token,
+    }
+    print(json.dumps(response))

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: Implementation :: CPython',
 ]
 
-CONSOLE_SCRIPTS = ['pierone = pierone.cli:main']
+CONSOLE_SCRIPTS = ['pierone = pierone.cli:main', 'docker-credential-pierone = pierone.credhelper:main']
 
 
 class PyTest(TestCommand):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 max-line-length=120
 
 [tox]
-envlist=py34,py35
+envlist=py34,py35,py36,py37,py38
 
 [testenv]
 commands=python setup.py test


### PR DESCRIPTION
Turns out that Pier One supports OAuth2 tokens smuggled via HTTP Basic auth, which means we can fix login issues and at the same time make `pierone login` something that the users only need to run once.

* Drop all arguments from `pierone login` except the optional `--url` option (they didn't do anything anyway).
* Add a `docker-credential-pierone` binary which uses `zign` to get a token and prints it in the format compatible with Docker.
* `pierone login` now removes the old-style configuration (`auths.…`) and simply configures the registry to use the new credentials helper.
* `pierone.api.docker_login` and `pierone.api.docker_login_with_token` are kept just in case someone relies on them, but they now print deprecation warnings. We can remove them later.

Fixes #81, #87, #91. Should also fix #86, but I'm not sure.