### PR TITLE
Check that the credential helper is available on the PATH

### DIFF
--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -1,6 +1,7 @@
 import sys
 import tarfile
 import tempfile
+import shutil
 
 import click
 import requests
@@ -85,6 +86,11 @@ def login(config, url):
 
     if not url_option_was_set:
         stups_cli.config.store_config(config, 'pierone')
+
+    # Check if the credential helper is available
+    if shutil.which("docker-credential-pierone") is None:
+        fatal_error("docker-credential-pierone executable is not available. "
+                    "If you've installed `pierone` to a virtual environment, make sure to add it to to the PATH.")
 
     docker_login_with_credhelper(url)
     ok("Authentication configured for {}, you don't need to run pierone login anymore!".format(url))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,6 +73,7 @@ def test_login(monkeypatch, tmpdir):
 
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {})
     monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('shutil.which', lambda x: x)
 
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ['login'], catch_exceptions=False, input='pieroneurl\n')
@@ -88,6 +89,7 @@ def test_login_update_config(monkeypatch, tmpdir):
 
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {})
     monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('shutil.which', lambda x: x)
 
     with runner.isolated_filesystem():
         os.makedirs(os.path.join(str(tmpdir), ".docker"))
@@ -146,8 +148,8 @@ def test_login_given_url_option(monkeypatch, tmpdir):
 
     monkeypatch.setattr('stups_cli.config.load_config', lambda x: {})
     monkeypatch.setattr('stups_cli.config.store_config', store)
-    monkeypatch.setattr('pierone.api.get_token', MagicMock(return_value='tok123'))
     monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
+    monkeypatch.setattr('shutil.which', lambda x: x)
 
     with runner.isolated_filesystem():
         runner.invoke(cli, ['login'], catch_exceptions=False, input='pieroneurl\n')


### PR DESCRIPTION
Our documentation for installing the tools was wrong for quite some time, and as a result some users have broken setups. Detect and warn them about this.