### PR TITLE
Fix sort order in output of scm-source

### DIFF
--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -357,7 +357,7 @@ def scm_source(config, team, artifact, tag, url, output):
             row['created_time'] = parse_time(''.join([d['created'] for d in matching_tag]))
         rows.append(row)
 
-    rows.sort(key=lambda row: (row['tag'], row.get('created_time')))
+    rows.sort(key=lambda row: (row.get('created_time'), row['tag']))
     with OutputFormat(output):
         print_table(['tag', 'author', 'url', 'revision', 'status', 'created_time', 'created_by'], rows,
                     titles={'tag': 'Tag', 'created_by': 'By', 'created_time': 'Created',


### PR DESCRIPTION
The order based on the tag doesn't match the time-based order of the `tags` command output, e.g:
```
master-10
master-11
master-2
master-3
```

This change makes both commands produce output in the same order.