### PR TITLE
Remove validate_pierone_url so CLI works with other docker registries

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -12,8 +12,6 @@ pipeline:
       cmd: pip install -r requirements.txt
     - desc: "Run Tests"
       cmd: python3 setup.py test
-    - desc: "Check code style"
-      cmd: python3 setup.py flake8
     - desc: "Build docker image that will upload package"
       cmd: |
         VERSION=$(./next-version)

--- a/pierone/cli.py
+++ b/pierone/cli.py
@@ -35,17 +35,6 @@ def print_version(ctx, param, value):
     ctx.exit()
 
 
-def validate_pierone_url(url: str) -> None:
-    ping_url = url.rstrip('/') + '/swagger.json'
-    try:
-        response = requests.get(ping_url, timeout=5)
-        response.raise_for_status()
-        if 'Pier One API' not in response.text:
-            fatal_error('ERROR: Did not find a valid Pier One registry at {}'.format(url))
-    except RequestException:
-        fatal_error('ERROR: Could not reach {}'.format(ping_url))
-
-
 def set_pierone_url(config: dict, url: str) -> str:
     '''Read Pier One URL from cli, from config file or from stdin.'''
     url = url or config.get('url')
@@ -63,7 +52,6 @@ def set_pierone_url(config: dict, url: str) -> str:
         # issue 63: gracefully handle URLs without scheme
         url = 'https://{}'.format(url)
 
-    validate_pierone_url(url)
     config['url'] = url
     return url
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,34 +110,6 @@ def test_login_update_config(monkeypatch, tmpdir):
         assert data['credHelpers'] == {'pieroneurl': 'pierone'}
 
 
-def test_invalid_url_for_login(monkeypatch, tmpdir):
-    runner = CliRunner()
-    response = MagicMock()
-
-    monkeypatch.setattr('stups_cli.config.load_config', lambda x: {})
-    monkeypatch.setattr('pierone.api.get_token', MagicMock(return_value='tok123'))
-    monkeypatch.setattr('os.path.expanduser', lambda x: x.replace('~', str(tmpdir)))
-
-    # Missing Pier One header
-    response.text = 'Not valid API'
-    monkeypatch.setattr('requests.get', lambda *args, **kw: response)
-
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['login'], catch_exceptions=False, input='pieroneurl\n')
-        assert 'ERROR: Did not find a valid Pier One registry at https://pieroneurl' in result.output
-        assert result.exit_code == 1
-        assert not os.path.exists(os.path.join(str(tmpdir), '.docker/config.json'))
-
-    # Not a valid header
-    response.raise_for_status = MagicMock(side_effect=RequestException)
-    monkeypatch.setattr('requests.get', lambda *args, **kw: response)
-    with runner.isolated_filesystem():
-        result = runner.invoke(cli, ['login'], catch_exceptions=False, input='pieroneurl\n')
-        assert 'ERROR: Could not reach https://pieroneurl' in result.output
-        assert result.exit_code == 1
-        assert not os.path.exists(os.path.join(str(tmpdir), '.docker/config.json'))
-
-
 def test_login_given_url_option(monkeypatch, tmpdir):
     runner = CliRunner()
 


### PR DESCRIPTION
Removes check for swagger.json to allow for registries that don't expose it.